### PR TITLE
Use frozen_string_literal

### DIFF
--- a/lib/outatime.rb
+++ b/lib/outatime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "aws-sdk"
 require "chronic"
 require "pathname"

--- a/lib/outatime/cli.rb
+++ b/lib/outatime/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Outatime
   class CLI
     attr_accessor :options

--- a/lib/outatime/fetcher.rb
+++ b/lib/outatime/fetcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread/pool'
 
 # Outatime::Fetcher is responsible for finding the exact revision for each file

--- a/lib/outatime/version.rb
+++ b/lib/outatime/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Outatime
   VERSION = "0.3.0"
 end

--- a/outatime.gemspec
+++ b/outatime.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "activesupport", "~> 5.0.0"
+  spec.add_development_dependency "activesupport", "~> 5.1.5"
   spec.add_development_dependency "byebug"
 end


### PR DESCRIPTION
Suggested by https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment/

Also fixes up a deprecation warning in the specs.